### PR TITLE
Use fast range instead of modulo for filter compression

### DIFF
--- a/gcs/builder/builder.go
+++ b/gcs/builder/builder.go
@@ -319,6 +319,11 @@ func BuildBasicFilter(block *wire.MsgBlock) (*gcs.Filter, error) {
 	// adding the outpoint data as well as the data pushes within the
 	// pkScript.
 	for i, tx := range block.Transactions {
+		// First we'll compute the bash of the transaction and add that
+		// directly to the filter.
+		txHash := tx.TxHash()
+		b.AddHash(&txHash)
+
 		// Skip the inputs for the coinbase transaction
 		if i != 0 {
 			// Each each txin, we'll add a serialized version of
@@ -358,11 +363,6 @@ func BuildExtFilter(block *wire.MsgBlock) (*gcs.Filter, error) {
 	// transaction as well as each piece of witness data included in both
 	// the sigScript and the witness stack of an input.
 	for i, tx := range block.Transactions {
-		// First we'll compute the bash of the transaction and add that
-		// directly to the filter.
-		txHash := tx.TxHash()
-		b.AddHash(&txHash)
-
 		// Skip the inputs for the coinbase transaction
 		if i != 0 {
 			// Next, for each input, we'll add the sigScript (if

--- a/gcs/builder/builder.go
+++ b/gcs/builder/builder.go
@@ -195,17 +195,31 @@ func (b *GCSBuilder) AddScript(script []byte) *GCSBuilder {
 		return b
 	}
 
-	return b.AddEntries(data)
+	b.AddEntries(data)
+
+	// Recurse into each pushed datum and attempt to add it as a script.
+	for _, datum := range data {
+		b.AddScript(datum)
+	}
+
+	return b
 }
 
-// AddWitness adds each item of the passed filter stack to the filer.
+// AddWitness adds each item of the passed filter stack to the filter, and then
+// adds each item as a script.
 func (b *GCSBuilder) AddWitness(witness wire.TxWitness) *GCSBuilder {
 	// Do nothing if the builder's already errored out.
 	if b.err != nil {
 		return b
 	}
 
-	return b.AddEntries(witness)
+	b.AddEntries(witness)
+
+	for _, script := range witness {
+		b.AddScript(script)
+	}
+
+	return b
 }
 
 // Build returns a function which builds a GCS filter with the given parameters

--- a/gcs/builder/builder_test.go
+++ b/gcs/builder/builder_test.go
@@ -261,7 +261,7 @@ func BuilderTest(b *builder.GCSBuilder, hash *chainhash.Hash, p uint8,
 	}
 	pushedData, err := txscript.PushedData(addrBytes)
 	if err != nil {
-		t.Fatalf("Couldn't extract pushed data from addrBytesess script: %s",
+		t.Fatalf("Couldn't extract pushed data from addrBytes script: %s",
 			err.Error())
 	}
 	match, err = f.MatchAny(key, pushedData)
@@ -269,17 +269,21 @@ func BuilderTest(b *builder.GCSBuilder, hash *chainhash.Hash, p uint8,
 		t.Fatalf("Filter match any failed: %s", err)
 	}
 	if !match {
-		t.Logf("Filter didn't match when it should have!")
+		t.Fatal("Filter didn't match when it should have!")
 	}
 
 	// Add a routine witness stack, build a filter, and test that it
 	// matches.
 	b.AddWitness(witness)
+	f, err = b.Build()
+	if err != nil {
+		t.Fatalf("Filter build failed: %s", err.Error())
+	}
 	match, err = f.MatchAny(key, witness)
 	if err != nil {
 		t.Fatalf("Filter match any failed: %s", err)
 	}
 	if !match {
-		t.Logf("Filter didn't match when it should have!")
+		t.Fatal("Filter didn't match when it should have!")
 	}
 }

--- a/gcs/gcsbench_test.go
+++ b/gcs/gcsbench_test.go
@@ -10,7 +10,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/btcsuite/btcutil/gcs"
+	"github.com/roasbeef/btcutil/gcs"
 )
 
 func genRandFilterElements(numElements uint) ([][]byte, error) {


### PR DESCRIPTION
Per the suggestion at https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-June/014530.html, this PR improves the performance of filter compression.