### PR TITLE
gcs: only use hash of pkscript to insert into filter

### DIFF
--- a/gcs/builder/builder.go
+++ b/gcs/builder/builder.go
@@ -331,7 +331,7 @@ func BuildBasicFilter(block *wire.MsgBlock) (*gcs.Filter, error) {
 		// For each output in a transaction, we'll add each of the
 		// individual data pushes within the script.
 		for _, txOut := range tx.TxOut {
-			b.AddScript(txOut.PkScript)
+			b.AddEntry(txOut.PkScript)
 		}
 	}
 

--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -52,7 +52,6 @@ const (
 // number to reduce, and our modulus N divided into its high 32-bits and lower
 // 32-bits.
 func fastReduction(v, nHi, nLo uint64) uint64 {
-
 	// First, we'll spit the item we need to reduce into its higher and
 	// lower bits.
 	vhi := v >> 32


### PR DESCRIPTION
In this commit, we make a slight change to BIP 158. Rather than
including *each* pushed data in the script, we instead just include the
script directly, which will eventually be hashed. The rationale for
doing this is two-fold:

  * Most scripts today and in the foreseeable future will just be a
    commitment.
  * Including *only* the script itself and not the hash of the script
    reduces the worst case filter size. Otherwise, an attacker could
    include a bunch of 2 byte push datas and blow up the filter size for
    all nodes.